### PR TITLE
Sort formulaDownloads by URL length in order to replace by longest match

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,8 @@ jobs:
         golint -set_exit_status ./...
     - name: test
       run: go test -coverprofile coverage.out -covermode atomic ./...
+      env:
+        GITHUB_TOKEN: ${{ secrets.github_token }}
     - name: Send coverage
       uses: shogo82148/actions-goveralls@v1
       with:

--- a/formula.go
+++ b/formula.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -133,6 +134,13 @@ func (fo *formula) update(ctx context.Context, ghcli *github.Client) (updated bo
 }
 
 func (fo *formula) updateContent(from, to []formulaDownload) {
+	// Sort formulaDownloads by URL length in order to replace by longest match.
+	sort.Slice(from, func(i, j int) bool {
+		return len(from[i].URL) > len(from[j].URL)
+	})
+	sort.Slice(to, func(i, j int) bool {
+		return len(to[i].URL) > len(to[j].URL)
+	})
 	var replacements []string
 	for _, fromD := range from {
 		for _, toD := range to {

--- a/formula_test.go
+++ b/formula_test.go
@@ -96,6 +96,33 @@ func TestUpdateContent(t *testing.T) {
 			Arch:   "amd64",
 		}},
 		expectFile: "testdata/kibelasync_update.rb",
+	}, {
+		name:    "partial matching url",
+		fname:   "testdata/ecspresso.rb",
+		version: "0.18.0",
+		fromDownloads: []formulaDownload{{
+			URL:    "https://github.com/kayac/ecspresso/releases/download/v0.17.3/ecspresso-v0.17.3-darwin-amd64",
+			SHA256: "1ac91503dcf2e7883b9df0d2a5b54c7c9a49e2d7b78f73286cfc19bb6ad44778",
+			OS:     "darwin",
+			Arch:   "amd64",
+		}, {
+			URL:    "https://github.com/kayac/ecspresso/releases/download/v0.17.3/ecspresso-v0.17.3-darwin-amd64.zip",
+			SHA256: "34684ce9b841eec0d30c809081bbf8269c1b9456301282fb54cf907d6687743d",
+			OS:     "darwin",
+			Arch:   "amd64",
+		}},
+		downloads: []formulaDownload{{
+			URL:    "https://github.com/kayac/ecspresso/releases/download/v0.18.0/ecspresso-v0.18.0-darwin-amd64",
+			SHA256: "44f7f90acf75ee38a18b50f5ff90de5b6d5ef8d3b639cf0942244a8a699e6aef",
+			OS:     "darwin",
+			Arch:   "amd64",
+		}, {
+			URL:    "https://github.com/kayac/ecspresso/releases/download/v0.18.0/ecspresso-v0.18.0-darwin-amd64.zip",
+			SHA256: "7fee5a7c401afd84e9b099aba37bea41572fd29731ddc3e4afe4bea4b3470a36",
+			OS:     "darwin",
+			Arch:   "amd64",
+		}},
+		expectFile: "testdata/ecspresso_update.rb",
 	}}
 
 	for _, tc := range testCases {

--- a/testdata/ecspresso.rb
+++ b/testdata/ecspresso.rb
@@ -1,0 +1,19 @@
+class Ecspresso < Formula
+  version '0.17.3'
+  homepage 'https://github.com/kayac/ecspresso'
+  url "https://github.com/kayac/ecspresso/releases/download/v0.17.3/ecspresso-v0.17.3-darwin-amd64.zip"
+  sha256 '34684ce9b841eec0d30c809081bbf8269c1b9456301282fb54cf907d6687743d'
+  head 'https://github.com/kayac/ecspresso.git'
+
+  head do
+    depends_on 'go' => :build
+  end
+
+  def install
+    if build.head?
+      system 'make', 'build'
+    end
+    system 'mv ecspresso-v*-*-amd64 ecspresso'
+    bin.install 'ecspresso'
+  end
+end

--- a/testdata/ecspresso_update.rb
+++ b/testdata/ecspresso_update.rb
@@ -1,0 +1,19 @@
+class Ecspresso < Formula
+  version '0.18.0'
+  homepage 'https://github.com/kayac/ecspresso'
+  url "https://github.com/kayac/ecspresso/releases/download/v0.18.0/ecspresso-v0.18.0-darwin-amd64.zip"
+  sha256 '7fee5a7c401afd84e9b099aba37bea41572fd29731ddc3e4afe4bea4b3470a36'
+  head 'https://github.com/kayac/ecspresso.git'
+
+  head do
+    depends_on 'go' => :build
+  end
+
+  def install
+    if build.head?
+      system 'make', 'build'
+    end
+    system 'mv ecspresso-v*-*-amd64 ecspresso'
+    bin.install 'ecspresso'
+  end
+end


### PR DESCRIPTION
When formulaDownloads contain partial matching URLs as below, replacer replaces wrong URL and SHA256 strings.

Sort formulaDownloads by URL length in order to replace by longest match.

```go
[]maltmill.formulaDownload{
	maltmill.formulaDownload{
		URL:    "https://github.com/kayac/ecspresso/releases/download/v0.18.0/ecspresso-v0.18.0-darwin-amd64",
		SHA256: "44f7f90acf75ee38a18b50f5ff90de5b6d5ef8d3b639cf0942244a8a699e6aef",
		OS:     "darwin",
		Arch:   "amd64",
	},
	maltmill.formulaDownload{
		URL:    "https://github.com/kayac/ecspresso/releases/download/v0.18.0/ecspresso-v0.18.0-darwin-amd64.zip",
		SHA256: "7fee5a7c401afd84e9b099aba37bea41572fd29731ddc3e4afe4bea4b3470a36",
		OS:     "darwin",
		Arch:   "amd64",
	},
```