### PR TITLE
Some updates to fit the current status of the maltmill

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ the Homebrew Formulae.
 % ghg get Songmu/maltmill
 ```
 
-### go get (for using HEAD)
+### go install (for using HEAD)
 
 ```console
-% go get github.com/Songmu/maltmill/cmd/maltmill
+% go install github.com/Songmu/maltmill/cmd/maltmill@main
 ```
 
 Built binaries are available on GitHub Releases.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 maltmill
 =======
 
-[![Build Status](https://travis-ci.org/Songmu/maltmill.png?branch=master)][travis]
+[![test](https://github.com/Songmu/maltmill/actions/workflows/test.yaml/badge.svg)][GitHub Actions]
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/Songmu/maltmill)][PkgGoDev]
 
-[travis]: https://travis-ci.org/Songmu/maltmill
+[GitHub Actions]: https://github.com/Songmu/maltmill/actions/workflows/test.yaml
 [license]: https://github.com/Songmu/maltmill/blob/master/LICENSE
 [PkgGoDev]: https://pkg.go.dev/github.com/Songmu/maltmill
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -3,7 +3,7 @@ package maltmill
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -11,7 +11,7 @@ func TestNew(t *testing.T) {
 	out := &bytes.Buffer{}
 	cl := &cli{
 		outStream: out,
-		errStream: ioutil.Discard,
+		errStream: io.Discard,
 	}
 	ctx := context.Background()
 	rnr, err := cl.parseArgs(ctx, []string{"new", "Songmu/maltmill@v0.0.1"})

--- a/formula.go
+++ b/formula.go
@@ -5,8 +5,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -33,7 +33,7 @@ var (
 )
 
 func newFormula(f string) (*formula, error) {
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return nil, err
 	}

--- a/formula_test.go
+++ b/formula_test.go
@@ -1,7 +1,7 @@
 package maltmill
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -134,7 +134,7 @@ func TestUpdateContent(t *testing.T) {
 			fo.version = tc.version
 			fo.updateContent(tc.fromDownloads, tc.downloads)
 
-			b, _ := ioutil.ReadFile(tc.expectFile)
+			b, _ := os.ReadFile(tc.expectFile)
 			expect := string(b)
 
 			if fo.content != expect {


### PR DESCRIPTION
I know this is an intervention, but I've updated some things to fit the current status of the maltmill.

- Use `io` or `os` since `io/ioutil` is deprecated
- Update README
    - Switch to GitHub Actions badge instead of TravisCI badge
    - Use `go install` instead of `go get`

