### PR TITLE
Make tag prefix configurable by `--tag-prefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ create and update Homebrew thrid party Formulae
 
 ```console
 % maltmill -w maltmill.rb
+% maltmill -w --tag-prefix my-product-v my-product.rb
 ```
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ create and update Homebrew thrid party Formulae
 % maltmill -w --tag-prefix my-product-v my-product.rb
 ```
 
+`--tag-prefix` is optional. If omitted, maltmill selects the latest release from
+plain semver tags (e.g. `1.2.3` / `v1.2.3`).
+
 ## Description
 
 The maltmill retrieve artifacts from GitHub Releases and create or update

--- a/cli.go
+++ b/cli.go
@@ -57,6 +57,7 @@ Commands:
 	var token string
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token")
 	fs.BoolVar(&mm.overwrite, "w", false, "write result to (source) file instead of stdout")
+	fs.StringVar(&mm.tagPrefix, "tag-prefix", "v", "tag `prefix` used to select releases")
 
 	err := fs.Parse(args)
 	if err != nil {
@@ -76,6 +77,7 @@ Commands:
 		if mm.overwrite {
 			newArgs = append(newArgs, "-w")
 		}
+		newArgs = append(newArgs, "-tag-prefix", mm.tagPrefix)
 		return cl.parseCmdNewArgs(ctx, append(newArgs, restArgs[1:]...))
 	default:
 		mm.files = restArgs
@@ -104,6 +106,7 @@ Options:
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token`")
 	fs.BoolVar(&cr.overwrite, "w", false, "write result to (source) file instead of stdout")
 	fs.StringVar(&cr.outFile, "o", "", "`file` to output")
+	fs.StringVar(&cr.tagPrefix, "tag-prefix", "v", "tag `prefix` used to select releases")
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -57,7 +57,7 @@ Commands:
 	var token string
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token")
 	fs.BoolVar(&mm.overwrite, "w", false, "write result to (source) file instead of stdout")
-	fs.StringVar(&mm.tagPrefix, "tag-prefix", "v", "tag `prefix` used to select releases")
+	fs.StringVar(&mm.tagPrefix, "tag-prefix", "", "tag `prefix` used to select releases")
 
 	err := fs.Parse(args)
 	if err != nil {
@@ -106,7 +106,7 @@ Options:
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token`")
 	fs.BoolVar(&cr.overwrite, "w", false, "write result to (source) file instead of stdout")
 	fs.StringVar(&cr.outFile, "o", "", "`file` to output")
-	fs.StringVar(&cr.tagPrefix, "tag-prefix", "v", "tag `prefix` used to select releases")
+	fs.StringVar(&cr.tagPrefix, "tag-prefix", "", "tag `prefix` used to select releases")
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cli_test.go
+++ b/cli_test.go
@@ -7,6 +7,46 @@ import (
 	"testing"
 )
 
+func TestParseArgsTagPrefix(t *testing.T) {
+	cl := &cli{
+		outStream: io.Discard,
+		errStream: io.Discard,
+	}
+	ctx := context.Background()
+
+	rnr, err := cl.parseArgs(ctx, []string{"-tag-prefix", "my-product-v", "testdata/goxz.rb"})
+	if err != nil {
+		t.Fatalf("parseArgs should not fail but: %s", err)
+	}
+	mm, ok := rnr.(*cmdMaltmill)
+	if !ok {
+		t.Fatalf("runner should be *cmdMaltmill but: %T", rnr)
+	}
+	if mm.tagPrefix != "my-product-v" {
+		t.Errorf("unexpected tagPrefix. out=%s expect=%s", mm.tagPrefix, "my-product-v")
+	}
+}
+
+func TestParseArgsTagPrefixForNew(t *testing.T) {
+	cl := &cli{
+		outStream: io.Discard,
+		errStream: io.Discard,
+	}
+	ctx := context.Background()
+
+	rnr, err := cl.parseArgs(ctx, []string{"-tag-prefix", "tool-v", "new", "Songmu/maltmill"})
+	if err != nil {
+		t.Fatalf("parseArgs should not fail but: %s", err)
+	}
+	cr, ok := rnr.(*cmdNew)
+	if !ok {
+		t.Fatalf("runner should be *cmdNew but: %T", rnr)
+	}
+	if cr.tagPrefix != "tool-v" {
+		t.Errorf("unexpected tagPrefix. out=%s expect=%s", cr.tagPrefix, "tool-v")
+	}
+}
+
 func TestNew(t *testing.T) {
 	out := &bytes.Buffer{}
 	cl := &cli{

--- a/cmd_maltmill.go
+++ b/cmd_maltmill.go
@@ -13,6 +13,7 @@ import (
 type cmdMaltmill struct {
 	files     []string
 	overwrite bool
+	tagPrefix string
 
 	writer io.Writer
 
@@ -37,6 +38,7 @@ func (mm *cmdMaltmill) processFile(ctx context.Context, f string) error {
 	if err != nil {
 		return err
 	}
+	fo.tagPrefix = mm.tagPrefix
 	updated, err := fo.update(ctx, mm.ghcli)
 	if err != nil {
 		return err

--- a/cmd_new.go
+++ b/cmd_new.go
@@ -202,7 +202,7 @@ func (cr *cmdNew) run(ctx context.Context) (err error) {
 		}
 	}
 
-	ver, _, err := parseTagName(rele.GetTagName())
+	ver, err := parseTagVersionWithPrefix(rele.GetTagName(), cr.tagPrefix)
 	if err != nil {
 		return errors.Wrapf(err, "invalid tag name: %s", rele.GetTagName())
 	}

--- a/cmd_new.go
+++ b/cmd_new.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/semver"
 	"github.com/google/go-github/v74/github"
 	"github.com/pkg/errors"
 )
@@ -21,6 +20,7 @@ type cmdNew struct {
 	slug      string
 	overwrite bool
 	outFile   string
+	tagPrefix string
 	ghcli     *github.Client
 }
 
@@ -188,18 +188,21 @@ func (cr *cmdNew) run(ctx context.Context) (err error) {
 	}
 	nf.Desc = repo.GetDescription()
 	resp.Body.Close()
-	rele, resp, err := func(ctx context.Context) (*github.RepositoryRelease, *github.Response, error) {
-		if tag == "" {
-			return cr.ghcli.Repositories.GetLatestRelease(ctx, nf.Owner, nf.Repo)
+	var rele *github.RepositoryRelease
+	if tag != "" {
+		rele, resp, err = cr.ghcli.Repositories.GetReleaseByTag(ctx, nf.Owner, nf.Repo, tag)
+		if err != nil {
+			return errors.Wrapf(err, "create new formula failed")
 		}
-		return cr.ghcli.Repositories.GetReleaseByTag(ctx, nf.Owner, nf.Repo, tag)
-	}(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "create new formula failed")
+		resp.Body.Close()
+	} else {
+		rele, _, err = findLatestReleaseByPrefix(ctx, cr.ghcli, nf.Owner, nf.Repo, cr.tagPrefix)
+		if err != nil {
+			return errors.Wrapf(err, "create new formula failed")
+		}
 	}
-	resp.Body.Close()
 
-	ver, err := semver.NewVersion(rele.GetTagName())
+	ver, _, err := parseTagName(rele.GetTagName())
 	if err != nil {
 		return errors.Wrapf(err, "invalid tag name: %s", rele.GetTagName())
 	}

--- a/formula_test.go
+++ b/formula_test.go
@@ -42,6 +42,16 @@ func TestParseTagVersionWithPrefix(t *testing.T) {
 		prefix:        "v",
 		expectVersion: "1.2.3",
 	}, {
+		name:          "empty prefix with plain semver",
+		tag:           "1.2.3",
+		prefix:        "",
+		expectVersion: "1.2.3",
+	}, {
+		name:          "empty prefix with v semver",
+		tag:           "v1.2.3",
+		prefix:        "",
+		expectVersion: "1.2.3",
+	}, {
 		name:          "product prefix",
 		tag:           "my-product-v0.8.1",
 		prefix:        "my-product-v",
@@ -103,6 +113,29 @@ func TestSelectLatestReleaseByPrefix(t *testing.T) {
 	}
 	if ver.String() != "1.4.0" {
 		t.Errorf("unexpected version. out=%s expect=%s", ver.String(), "1.4.0")
+	}
+}
+
+func TestSelectLatestReleaseByPrefixWithEmptyPrefix(t *testing.T) {
+	releases := []*github.RepositoryRelease{{
+		TagName: github.String("1.1.0"),
+	}, {
+		TagName: github.String("v1.3.0"),
+	}, {
+		TagName: github.String("my-product-v9.9.9"),
+	}, {
+		TagName: github.String("1.2.0"),
+	}}
+
+	rele, ver := selectLatestReleaseByPrefix(releases, "")
+	if rele == nil || ver == nil {
+		t.Fatal("release and version should not be nil")
+	}
+	if rele.GetTagName() != "v1.3.0" {
+		t.Errorf("unexpected release. out=%s expect=%s", rele.GetTagName(), "v1.3.0")
+	}
+	if ver.String() != "1.3.0" {
+		t.Errorf("unexpected version. out=%s expect=%s", ver.String(), "1.3.0")
 	}
 }
 

--- a/formula_test.go
+++ b/formula_test.go
@@ -29,32 +29,43 @@ func TestNewFormula(t *testing.T) {
 	}
 }
 
-func TestParseTagName(t *testing.T) {
+func TestParseTagVersionWithPrefix(t *testing.T) {
 	testCases := []struct {
 		name          string
 		tag           string
+		prefix        string
 		expectVersion string
-		expectPrefix  string
 		expectErr     bool
 	}{{
 		name:          "v prefix",
 		tag:           "v1.2.3",
+		prefix:        "v",
 		expectVersion: "1.2.3",
-		expectPrefix:  "v",
 	}, {
 		name:          "product prefix",
 		tag:           "my-product-v0.8.1",
+		prefix:        "my-product-v",
 		expectVersion: "0.8.1",
-		expectPrefix:  "my-product-v",
+	}, {
+		name:      "too many version segments",
+		tag:       "v1.2.3.4",
+		prefix:    "v",
+		expectErr: true,
+	}, {
+		name:      "prefix mismatch",
+		tag:       "other-v1.2.3",
+		prefix:    "my-product-v",
+		expectErr: true,
 	}, {
 		name:      "invalid tag",
 		tag:       "main",
+		prefix:    "v",
 		expectErr: true,
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ver, prefix, err := parseTagName(tc.tag)
+			ver, err := parseTagVersionWithPrefix(tc.tag, tc.prefix)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("error should not be nil for tag %q", tc.tag)
@@ -66,9 +77,6 @@ func TestParseTagName(t *testing.T) {
 			}
 			if ver.String() != tc.expectVersion {
 				t.Errorf("unexpected version. out=%s expect=%s", ver.String(), tc.expectVersion)
-			}
-			if prefix != tc.expectPrefix {
-				t.Errorf("unexpected prefix. out=%s expect=%s", prefix, tc.expectPrefix)
 			}
 		})
 	}


### PR DESCRIPTION
Thank you for sharing a great product with OSS community! 🤝 
Here I want to ask for adding an optional commandline option to make maltmill working with [release-please](https://github.com/googleapis/release-please).

### Description
This PR makes tag-prefix handling configurable via the `--tag-prefix` option.

- Added `--tag-prefix` to both `maltmill` (update) and `maltmill new`.
- Release selection now uses the latest release that matches the configured prefix, instead of using the repository-wide latest release.
- Updated tests for prefix-aware selection and CLI argument parsing.
- Updated README examples to use `--tag-prefix`.
- Confirmed that this change works as expected in my local, here is the [generated formlae](https://github.com/KengoTODA/homebrew-tap/blob/2637ee39ad3197d30be5725593b4c491ba23bcd7/inspequte.rb) with `--tag-prefix inspequte-v` option.

### Why
I use `release-please` to handle automatic release from monorepo projects and such projects contain multiple release streams (different products/components) under different tag prefixes.
In case of [inspequte](https://github.com/KengoTODA/inspequte/), it has `inspequte-vX.Y.Z` stream and `gradle-plugin-vX.Y.Z` stream.

Without explicit prefix filtering, maltmill can pick an unrelated release/tag and update formulae incorrectly.  
Making the prefix configurable ensures the intended product stream is selected.

### Compatibility
- `--tag-prefix` is optional.
- Default remains `v`, so common `vX.Y.Z` repositories continue to work without changes.
- Repositories using other prefixes should pass `--tag-prefix <prefix>` to avoid cross-stream release selection.