### PR TITLE
Add -asset flag to filter release assets by filename pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ If the repository uses prefixed tags (e.g. `my-product-v1.2.3`), use
 If `--tag-prefix` is omitted, maltmill selects the latest release from
 plain semver tags (e.g. `v1.2.3` or `1.2.3`).
 
+If a release contains non-archive assets such as `.rpm` or `.deb`
+packages alongside `.tar.gz` / `.zip` archives, maltmill may pick the
+wrong file. Use `-asset` to narrow down which assets to consider:
+
+```console
+% maltmill -w -asset '\.(tar\.gz|zip)$' my-tool.rb
+```
+
+The value is a Go regular expression matched against each asset filename.
+
 Without `-w`, the updated formula is printed to stdout.
 
 ## Install
@@ -116,6 +126,7 @@ credential helpers).
 | `-w` | Write the result back to the source file instead of stdout |
 | `-token` | GitHub API token (default: `$GITHUB_TOKEN`) |
 | `-tag-prefix` | Tag prefix used to select releases (e.g. `my-product-v`) |
+| `-asset` | Regexp pattern to select release assets by filename (e.g. `\.tar\.gz$`) |
 
 ### `new` subcommand options
 
@@ -125,6 +136,7 @@ credential helpers).
 | `-o` | Specify the output file path |
 | `-token` | GitHub API token (default: `$GITHUB_TOKEN`) |
 | `-tag-prefix` | Tag prefix used to select releases |
+| `-asset` | Regexp pattern to select release assets by filename |
 
 ## Author
 

--- a/cli.go
+++ b/cli.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"runtime"
 
 	"github.com/pkg/errors"
@@ -55,13 +56,22 @@ Commands:
 `)
 	}
 	var token string
+	var assetPatternStr string
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token")
 	fs.BoolVar(&mm.overwrite, "w", false, "write result to (source) file instead of stdout")
 	fs.StringVar(&mm.tagPrefix, "tag-prefix", "", "tag `prefix` used to select releases")
+	fs.StringVar(&assetPatternStr, "asset", "", "regexp `pattern` to select release assets by filename")
 
 	err := fs.Parse(args)
 	if err != nil {
 		return nil, err
+	}
+
+	if assetPatternStr != "" {
+		mm.assetPattern, err = regexp.Compile(assetPatternStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid asset pattern: %s", assetPatternStr)
+		}
 	}
 
 	restArgs := fs.Args()
@@ -78,6 +88,9 @@ Commands:
 			newArgs = append(newArgs, "-w")
 		}
 		newArgs = append(newArgs, "-tag-prefix", mm.tagPrefix)
+		if assetPatternStr != "" {
+			newArgs = append(newArgs, "-asset", assetPatternStr)
+		}
 		return cl.parseCmdNewArgs(ctx, append(newArgs, restArgs[1:]...))
 	default:
 		mm.files = restArgs
@@ -103,14 +116,22 @@ Options:
 		fs.PrintDefaults()
 	}
 	var token string
+	var assetPatternStr string
 	fs.StringVar(&token, "token", os.Getenv(envGitHubToken), "github `token`")
 	fs.BoolVar(&cr.overwrite, "w", false, "write result to (source) file instead of stdout")
 	fs.StringVar(&cr.outFile, "o", "", "`file` to output")
 	fs.StringVar(&cr.tagPrefix, "tag-prefix", "", "tag `prefix` used to select releases")
+	fs.StringVar(&assetPatternStr, "asset", "", "regexp `pattern` to select release assets by filename")
 
 	err := fs.Parse(args)
 	if err != nil {
 		return nil, err
+	}
+	if assetPatternStr != "" {
+		cr.assetPattern, err = regexp.Compile(assetPatternStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid asset pattern: %s", assetPatternStr)
+		}
 	}
 	if len(fs.Args()) < 1 {
 		return nil, errors.New("githut repository isn't specified")

--- a/cli_test.go
+++ b/cli_test.go
@@ -47,6 +47,52 @@ func TestParseArgsTagPrefixForNew(t *testing.T) {
 	}
 }
 
+func TestParseArgsAssetPattern(t *testing.T) {
+	cl := &cli{
+		outStream: io.Discard,
+		errStream: io.Discard,
+	}
+	ctx := context.Background()
+
+	rnr, err := cl.parseArgs(ctx, []string{"-asset", `\.tar\.gz$`, "testdata/goxz.rb"})
+	if err != nil {
+		t.Fatalf("parseArgs should not fail but: %s", err)
+	}
+	mm, ok := rnr.(*cmdMaltmill)
+	if !ok {
+		t.Fatalf("runner should be *cmdMaltmill but: %T", rnr)
+	}
+	if mm.assetPattern == nil {
+		t.Fatal("assetPattern should not be nil")
+	}
+	if mm.assetPattern.String() != `\.tar\.gz$` {
+		t.Errorf("unexpected assetPattern. out=%s expect=%s", mm.assetPattern.String(), `\.tar\.gz$`)
+	}
+}
+
+func TestParseArgsAssetPatternForNew(t *testing.T) {
+	cl := &cli{
+		outStream: io.Discard,
+		errStream: io.Discard,
+	}
+	ctx := context.Background()
+
+	rnr, err := cl.parseArgs(ctx, []string{"-asset", `\.zip$`, "new", "Songmu/maltmill"})
+	if err != nil {
+		t.Fatalf("parseArgs should not fail but: %s", err)
+	}
+	cr, ok := rnr.(*cmdNew)
+	if !ok {
+		t.Fatalf("runner should be *cmdNew but: %T", rnr)
+	}
+	if cr.assetPattern == nil {
+		t.Fatal("assetPattern should not be nil")
+	}
+	if cr.assetPattern.String() != `\.zip$` {
+		t.Errorf("unexpected assetPattern. out=%s expect=%s", cr.assetPattern.String(), `\.zip$`)
+	}
+}
+
 func TestNew(t *testing.T) {
 	out := &bytes.Buffer{}
 	cl := &cli{

--- a/cmd_maltmill.go
+++ b/cmd_maltmill.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 
 	"github.com/google/go-github/v84/github"
 	"golang.org/x/sync/errgroup"
 )
 
 type cmdMaltmill struct {
-	files     []string
-	overwrite bool
-	tagPrefix string
+	files        []string
+	overwrite    bool
+	tagPrefix    string
+	assetPattern *regexp.Regexp
 
 	writer io.Writer
 
@@ -39,6 +41,7 @@ func (mm *cmdMaltmill) processFile(ctx context.Context, f string) error {
 		return err
 	}
 	fo.tagPrefix = mm.tagPrefix
+	fo.assetPattern = mm.assetPattern
 	updated, err := fo.update(ctx, mm.ghcli)
 	if err != nil {
 		return err

--- a/cmd_new.go
+++ b/cmd_new.go
@@ -16,12 +16,13 @@ import (
 )
 
 type cmdNew struct {
-	writer    io.Writer
-	slug      string
-	overwrite bool
-	outFile   string
-	tagPrefix string
-	ghcli     *github.Client
+	writer       io.Writer
+	slug         string
+	overwrite    bool
+	outFile      string
+	tagPrefix    string
+	assetPattern *regexp.Regexp
+	ghcli        *github.Client
 }
 
 var _ runner = (*cmdNew)(nil)
@@ -126,11 +127,14 @@ var formulaTmpl = template.Must(
 
 var osNameRe = regexp.MustCompile("(darwin|linux)")
 
-func getDownloads(assets []*github.ReleaseAsset) ([]formulaDownload, error) {
+func getDownloads(assets []*github.ReleaseAsset, assetPattern *regexp.Regexp) ([]formulaDownload, error) {
 	var downloads []formulaDownload
 	for _, asset := range assets {
 		u := asset.GetBrowserDownloadURL()
 		fname := path.Base(u)
+		if assetPattern != nil && !assetPattern.MatchString(fname) {
+			continue
+		}
 		arch, ok := detectArch(fname)
 		if !ok {
 			continue
@@ -218,7 +222,7 @@ func (cr *cmdNew) run(ctx context.Context) (err error) {
 		return errors.Wrapf(err, "invalid tag name: %s", rele.GetTagName())
 	}
 	nf.Version = fmt.Sprintf("%d.%d.%d", ver.Major(), ver.Minor(), ver.Patch())
-	downloads, err := getDownloads(rele.Assets)
+	downloads, err := getDownloads(rele.Assets, cr.assetPattern)
 	if err != nil {
 		return err
 	}

--- a/formula.go
+++ b/formula.go
@@ -23,6 +23,7 @@ type formula struct {
 	name, version string
 	owner, repo   string
 	tagPrefix     string
+	assetPattern  *regexp.Regexp
 }
 
 var (
@@ -107,11 +108,11 @@ func (fo *formula) update(ctx context.Context, ghcli *github.Client) (updated bo
 	}
 
 	newVerStr := fmt.Sprintf("%d.%d.%d", newVer.Major(), newVer.Minor(), newVer.Patch())
-	fromDownloads, err := getDownloads(fromRele.Assets)
+	fromDownloads, err := getDownloads(fromRele.Assets, fo.assetPattern)
 	if err != nil {
 		return false, errors.Wrapf(err, "update formula failed: %s", fo.fname)
 	}
-	downloads, err := getDownloads(rele.Assets)
+	downloads, err := getDownloads(rele.Assets, fo.assetPattern)
 	if err != nil {
 		return false, errors.Wrapf(err, "update formula failed: %s", fo.fname)
 	}

--- a/formula_test.go
+++ b/formula_test.go
@@ -3,6 +3,8 @@ package maltmill
 import (
 	"os"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v84/github"
@@ -301,6 +303,72 @@ func TestUpdateContent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetDownloadsWithAssetPattern(t *testing.T) {
+	assets := []*github.ReleaseAsset{{
+		BrowserDownloadURL: github.String("https://github.com/example/tool/releases/download/v1.0.0/tool_v1.0.0_darwin_amd64.tar.gz"),
+		Digest:             github.String("sha256:aaaa"),
+	}, {
+		BrowserDownloadURL: github.String("https://github.com/example/tool/releases/download/v1.0.0/tool_v1.0.0_darwin_amd64.zip"),
+		Digest:             github.String("sha256:bbbb"),
+	}, {
+		BrowserDownloadURL: github.String("https://github.com/example/tool/releases/download/v1.0.0/tool_v1.0.0_linux_amd64.tar.gz"),
+		Digest:             github.String("sha256:cccc"),
+	}, {
+		BrowserDownloadURL: github.String("https://github.com/example/tool/releases/download/v1.0.0/tool_v1.0.0_linux_amd64.zip"),
+		Digest:             github.String("sha256:dddd"),
+	}}
+
+	t.Run("no filter returns all", func(t *testing.T) {
+		downloads, err := getDownloads(assets, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(downloads) != 4 {
+			t.Errorf("expected 4 downloads, got %d", len(downloads))
+		}
+	})
+
+	t.Run("filter by tar.gz", func(t *testing.T) {
+		filter := regexp.MustCompile(`\.tar\.gz$`)
+		downloads, err := getDownloads(assets, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(downloads) != 2 {
+			t.Errorf("expected 2 downloads, got %d", len(downloads))
+		}
+		for _, d := range downloads {
+			if !strings.HasSuffix(d.URL, ".tar.gz") {
+				t.Errorf("expected .tar.gz URL, got %s", d.URL)
+			}
+		}
+	})
+
+	t.Run("filter by zip", func(t *testing.T) {
+		filter := regexp.MustCompile(`\.zip$`)
+		downloads, err := getDownloads(assets, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(downloads) != 2 {
+			t.Errorf("expected 2 downloads, got %d", len(downloads))
+		}
+		for _, d := range downloads {
+			if !strings.HasSuffix(d.URL, ".zip") {
+				t.Errorf("expected .zip URL, got %s", d.URL)
+			}
+		}
+	})
+
+	t.Run("filter matches nothing", func(t *testing.T) {
+		filter := regexp.MustCompile(`\.deb$`)
+		_, err := getDownloads(assets, filter)
+		if err == nil {
+			t.Error("expected error when no assets match filter")
+		}
+	})
 }
 
 func TestGetSHA256FromURL(t *testing.T) {


### PR DESCRIPTION
When a release contains non-archive assets (e.g. .rpm, .deb) alongside .tar.gz/.zip, maltmill could pick the wrong file. The -asset flag accepts a regexp pattern to select which assets to consider.